### PR TITLE
hack to EE BB add-on to resolve issue 13

### DIFF
--- a/EE_Beaver_Builder.class.php
+++ b/EE_Beaver_Builder.class.php
@@ -116,6 +116,8 @@ Class  EE_Beaver_Builder extends EE_Addon
         if (class_exists('EE_Calendar')) {
             require_once 'beaver-builder-modules/events-calendar/events-calendar.php';
         }
+        //this may not be the best spot to enqueue it, especially if the add-on gets de-registered
+	    add_action('wp_enqueue_scripts', array('EE_Beaver_Builder','enqueueJsAndCss'));
     }
 
 
@@ -131,6 +133,22 @@ Class  EE_Beaver_Builder extends EE_Addon
     public function after_registration()
     {
         // your logic here
+
+    }
+
+
+
+	/**
+	 * Enqueue global CSS and JS (ie, stuff we want to work on the front-end and back-end)
+	 */
+    public static function enqueueJsAndCss()
+    {
+	    wp_enqueue_style(
+		    'espresso_beaver_builder',
+		    EE_BEAVER_BUILDER_URL . '/css/espresso_beaver_builder.css',
+		    array(),
+		    EE_BEAVER_BUILDER_VERSION
+	    );
     }
 
 

--- a/css/espresso_beaver_builder.css
+++ b/css/espresso_beaver_builder.css
@@ -23,3 +23,9 @@ General Styles
 @media only screen and (max-width: 480px) {
 }
 
+/*
+Hack to resolve https://github.com/eventespresso/eea-beaver-builder/issues/13
+ */
+.fl-editor-field .hide-if-no-js {
+	display: block;
+}


### PR DESCRIPTION
Applies Tony's hack from https://eventespresso.com/topic/ee-breaking-beaver-builder-page-builder-wysiwyg-visual-text-tabs/#post-268371 to resolve the issue where BB text field's "Visual" and "Text" tabs are hidden.
This could be registered better and maybe we could instead have EE's logic that reveals these inputs work on the front-end too, but this hack seems to work good enough