### PR TITLE
Fixes broken btn align option

### DIFF
--- a/beaver-builder-modules/events-list/includes/frontend.css.php
+++ b/beaver-builder-modules/events-list/includes/frontend.css.php
@@ -160,7 +160,7 @@ if( !empty($settings->list_description) ) { ?>
                 break;
                 case 'right':
                     ?>
-                    float: rigth;
+                    float: right;
                     text-align: right;
                     <?php
                 break;

--- a/beaver-builder-modules/ticket-selector/includes/frontend.css.php
+++ b/beaver-builder-modules/ticket-selector/includes/frontend.css.php
@@ -192,7 +192,7 @@
                 break;
                 case 'right':
                     ?>
-                    float: rigth;
+                    float: right;
                     text-align: right;
                     <?php
                 break;


### PR DESCRIPTION
When aligning a button right it will not do so as right is misspelled.